### PR TITLE
Update DiscreteUtility-Utility to use cascade delete

### DIFF
--- a/PrismaApi/PrismaApi.Infrastructure/Context/AppDbContext.cs
+++ b/PrismaApi/PrismaApi.Infrastructure/Context/AppDbContext.cs
@@ -272,7 +272,7 @@ public class AppDbContext : DbContext
             entity.HasOne(e => e.Utility)
                 .WithMany(e => e.DiscreteUtilities)
                 .HasForeignKey(e => e.UtilityId)
-                .OnDelete(DeleteBehavior.NoAction);
+                .OnDelete(DeleteBehavior.Cascade);
 
             entity.HasMany(e => e.ParentOutcomes)
                 .WithOne(e => e.DiscreteUtility)

--- a/PrismaApi/PrismaApi.Infrastructure/Migrations/20260407134123_CascadeUtilities.Designer.cs
+++ b/PrismaApi/PrismaApi.Infrastructure/Migrations/20260407134123_CascadeUtilities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PrismaApi.Infrastructure.Context;
 
@@ -11,9 +12,11 @@ using PrismaApi.Infrastructure.Context;
 namespace PrismaApi.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407134123_CascadeUtilities")]
+    partial class CascadeUtilities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PrismaApi/PrismaApi.Infrastructure/Migrations/20260407134123_CascadeUtilities.cs
+++ b/PrismaApi/PrismaApi.Infrastructure/Migrations/20260407134123_CascadeUtilities.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PrismaApi.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class CascadeUtilities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DiscreteUtilities_Utilities_UtilityId",
+                table: "DiscreteUtilities");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DiscreteUtilities_Utilities_UtilityId",
+                table: "DiscreteUtilities",
+                column: "UtilityId",
+                principalTable: "Utilities",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DiscreteUtilities_Utilities_UtilityId",
+                table: "DiscreteUtilities");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DiscreteUtilities_Utilities_UtilityId",
+                table: "DiscreteUtilities",
+                column: "UtilityId",
+                principalTable: "Utilities",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
Changed the DiscreteUtility-Utility foreign key to use cascade delete instead of no action. Added a new EF Core migration to update the database schema and updated the model snapshot to reflect this behavior. Now, deleting a Utility will also delete its related DiscreteUtility records.