### PR TITLE
Refactor DTO to entity mapping in CreateAsync method

### DIFF
--- a/PrismaApi/PrismaApi.Application/Mapping/DiscreteTableMappingExtensions.cs
+++ b/PrismaApi/PrismaApi.Application/Mapping/DiscreteTableMappingExtensions.cs
@@ -64,6 +64,11 @@ public static class DiscreteTableMappingExtensions
         return entities.Select(ToDto).ToList();
     }
 
+    public static List<DiscreteProbability> ToEntities(this IEnumerable<DiscreteProbabilityDto> dtos)
+    {
+        return dtos.Select(ToEntity).ToList();
+    }
+
     public static DiscreteProbabilityParentOutcomeDto ToDto(this DiscreteProbabilityParentOutcome entity)
     {
         return new DiscreteProbabilityParentOutcomeDto

--- a/PrismaApi/PrismaApi.Application/Services/DiscreteProbabilityService.cs
+++ b/PrismaApi/PrismaApi.Application/Services/DiscreteProbabilityService.cs
@@ -22,7 +22,9 @@ public class DiscreteProbabilityService: IDiscreteProbabilityService
 
     public async Task<List<DiscreteProbabilityDto>> CreateAsync(List<DiscreteProbabilityDto> dtos, CancellationToken ct = default)
     {
-        var entities = dtos.ToEntitiesWithoutParents();
+        var entities = dtos
+            .Select(x => x.ToEntity())
+            .ToList();
         await _discreteProbabilityRepository.AddRangeAsync(entities, ct);
         return entities.ToDtos();
     }

--- a/PrismaApi/PrismaApi.Application/Services/DiscreteProbabilityService.cs
+++ b/PrismaApi/PrismaApi.Application/Services/DiscreteProbabilityService.cs
@@ -22,9 +22,7 @@ public class DiscreteProbabilityService: IDiscreteProbabilityService
 
     public async Task<List<DiscreteProbabilityDto>> CreateAsync(List<DiscreteProbabilityDto> dtos, CancellationToken ct = default)
     {
-        var entities = dtos
-            .Select(x => x.ToEntity())
-            .ToList();
+        var entities = dtos.ToEntities();
         await _discreteProbabilityRepository.AddRangeAsync(entities, ct);
         return entities.ToDtos();
     }


### PR DESCRIPTION
Changed CreateAsync to map DTOs to entities using .Select(x => x.ToEntity()) instead of ToEntitiesWithoutParents(), providing clearer and more explicit conversion logic.