### PR TITLE
Improve case-insensitive Boundary comparisons in queries

### DIFF
--- a/PrismaApi/PrismaApi.Application/Repositories/EdgeRepository.cs
+++ b/PrismaApi/PrismaApi.Application/Repositories/EdgeRepository.cs
@@ -91,14 +91,14 @@ public static class EdgeQueryableExtensions
         return query
             .Where(e =>
                 e.ProjectId == projectId &&
-                (e.TailNode!.Issue!.Boundary == Boundary.In.ToString() || e.TailNode.Issue.Boundary == Boundary.On.ToString()) &&
+                (e.TailNode!.Issue!.Boundary.ToUpper() == Boundary.In.ToString().ToUpper() || e.TailNode.Issue.Boundary.ToUpper() == Boundary.On.ToString().ToUpper()) &&
                 (e.TailNode.Issue.Type == IssueType.Uncertainty.ToString() || e.TailNode.Issue.Type == IssueType.Decision.ToString() || e.TailNode.Issue.Type == IssueType.Utility.ToString()) &&
                 (
                     (e.TailNode.Issue.Type == IssueType.Uncertainty.ToString() && e.TailNode.Issue.Uncertainty!.IsKey == true) ||
                     (e.TailNode.Issue.Type == IssueType.Decision.ToString() && e.TailNode.Issue.Decision!.Type == DecisionHierarchy.Focus.ToString()) ||
                     (e.TailNode.Issue.Type == IssueType.Utility.ToString())
                 ) &&
-                (e.HeadNode!.Issue!.Boundary == Boundary.In.ToString() || e.HeadNode.Issue.Boundary == Boundary.On.ToString()) &&
+                (e.HeadNode!.Issue!.Boundary.ToUpper() == Boundary.In.ToString().ToUpper() || e.HeadNode.Issue.Boundary.ToUpper() == Boundary.On.ToString().ToUpper()) &&
                 (e.HeadNode.Issue.Type == IssueType.Uncertainty.ToString() || e.HeadNode.Issue.Type == IssueType.Decision.ToString() || e.HeadNode.Issue.Type == IssueType.Utility.ToString()) &&
                 (
                     (e.HeadNode.Issue.Type == IssueType.Uncertainty.ToString() && e.HeadNode.Issue.Uncertainty!.IsKey == true) ||

--- a/PrismaApi/PrismaApi.Application/Repositories/IssueRepository.cs
+++ b/PrismaApi/PrismaApi.Application/Repositories/IssueRepository.cs
@@ -86,8 +86,8 @@ public class IssueRepository : BaseRepository<Issue, Guid>, IIssueRepository
     private bool WillIssueChangeTables(Issue entity, Issue incomingEntity)
     {
         if (entity.Type != incomingEntity.Type) return true;
-        if (!string.Equals(entity.Boundary, incomingEntity.Boundary, StringComparison.CurrentCultureIgnoreCase)
-            && (incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase) || entity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase))) 
+        if (!string.Equals(entity.Boundary, incomingEntity.Boundary, StringComparison.OrdinalIgnoreCase)
+            && (incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.OrdinalIgnoreCase) || entity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.OrdinalIgnoreCase))) 
             return true;
         return false;
     }

--- a/PrismaApi/PrismaApi.Application/Repositories/IssueRepository.cs
+++ b/PrismaApi/PrismaApi.Application/Repositories/IssueRepository.cs
@@ -86,7 +86,9 @@ public class IssueRepository : BaseRepository<Issue, Guid>, IIssueRepository
     private bool WillIssueChangeTables(Issue entity, Issue incomingEntity)
     {
         if (entity.Type != incomingEntity.Type) return true;
-        if (entity.Boundary != incomingEntity.Boundary && (incomingEntity.Boundary == Boundary.Out.ToString() || entity.Boundary == Boundary.Out.ToString())) return true;
+        if (!string.Equals(entity.Boundary, incomingEntity.Boundary, StringComparison.CurrentCultureIgnoreCase)
+            && (incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase) || entity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase))) 
+            return true;
         return false;
     }
 
@@ -127,7 +129,7 @@ public static class IssueQueryableExtensions
         return query
             .Where(e =>
                 e.ProjectId == projectId &&
-                (e.Boundary == Boundary.In.ToString() || e.Boundary == Boundary.On.ToString()) &&
+                (e.Boundary.ToUpper() == Boundary.In.ToString().ToUpper() || e.Boundary.ToUpper() == Boundary.On.ToString().ToUpper()) &&
                 (e.Type == IssueType.Uncertainty.ToString() || e.Type == IssueType.Decision.ToString() || e.Type == IssueType.Utility.ToString()) &&
                 (
                     (e.Type == IssueType.Uncertainty.ToString() && e.Uncertainty!.IsKey == true) ||

--- a/PrismaApi/PrismaApi.Application/Repositories/RepositoryUtilities.cs
+++ b/PrismaApi/PrismaApi.Application/Repositories/RepositoryUtilities.cs
@@ -69,7 +69,7 @@ public static class RepositoryUtilities
     public static bool IsDecisionMovedOutOfStrategyTable(Issue entity, Issue incomingEntity)
     {
         if (entity.Type != incomingEntity.Type && entity.Type == IssueType.Decision.ToString()) return true;
-        if (!entity.Boundary.Equals(incomingEntity.Boundary, StringComparison.CurrentCultureIgnoreCase) && incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase)) return true;
+        if (!entity.Boundary.Equals(incomingEntity.Boundary, StringComparison.OrdinalIgnoreCase) && incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.OrdinalIgnoreCase)) return true;
         if (entity.Decision != null && incomingEntity.Decision != null && entity.Decision.Type != incomingEntity.Decision.Type && entity.Decision.Type == DecisionHierarchy.Focus.ToString()) return true;
         return false;
     }

--- a/PrismaApi/PrismaApi.Application/Repositories/RepositoryUtilities.cs
+++ b/PrismaApi/PrismaApi.Application/Repositories/RepositoryUtilities.cs
@@ -69,7 +69,7 @@ public static class RepositoryUtilities
     public static bool IsDecisionMovedOutOfStrategyTable(Issue entity, Issue incomingEntity)
     {
         if (entity.Type != incomingEntity.Type && entity.Type == IssueType.Decision.ToString()) return true;
-        if (entity.Boundary != incomingEntity.Boundary && incomingEntity.Boundary == Boundary.Out.ToString()) return true;
+        if (!entity.Boundary.Equals(incomingEntity.Boundary, StringComparison.CurrentCultureIgnoreCase) && incomingEntity.Boundary.Equals(Boundary.Out.ToString(), StringComparison.CurrentCultureIgnoreCase)) return true;
         if (entity.Decision != null && incomingEntity.Decision != null && entity.Decision.Type != incomingEntity.Decision.Type && entity.Decision.Type == DecisionHierarchy.Focus.ToString()) return true;
         return false;
     }


### PR DESCRIPTION
Updated LINQ queries and logic to use case-insensitive string comparisons for the Boundary property. This includes using .ToUpper() or string.Equals with StringComparison.CurrentCultureIgnoreCase in EdgeQueryableExtensions, IssueQueryableExtensions, IssueRepository, and RepositoryUtilities. These changes ensure consistent behavior regardless of string casing and prevent bugs from inconsistent boundary value casing.