### PR TITLE
Add utilities CRUD API and table cleanup endpoints

### DIFF
--- a/PrismaApi/PrismaApi.Api/Controllers/UncertaintiesController.cs
+++ b/PrismaApi/PrismaApi.Api/Controllers/UncertaintiesController.cs
@@ -120,7 +120,7 @@ public class UncertaintiesController : PrismaBaseEntityController
             // check that the user has access to the uncertainty
             var uncertainty = await _uncertaintyService.GetAsync([id], user, ct) ?? throw new ArgumentException($"Uncertainty {id} not found or User lacks access to the Project");
 
-            await _tableRebuildingService.RemoveExcessProbabilities(id, ct);
+            await _tableRebuildingService.RemoveExcessDiscreteProbabilities(id, ct);
             await CommitTransactionAsync(ct);
             return NoContent();
         }

--- a/PrismaApi/PrismaApi.Api/Controllers/UtilitesController.cs
+++ b/PrismaApi/PrismaApi.Api/Controllers/UtilitesController.cs
@@ -12,48 +12,48 @@ namespace PrismaApi.Api.Controllers;
 
 [ApiController]
 [Route("")]
-public class UncertaintiesController : PrismaBaseEntityController
+public class utilitiesController : PrismaBaseEntityController
 {
-    private readonly IUncertaintyService _uncertaintyService;
+    private readonly IUtilityService _utilityService;
     private readonly ITableRebuildingService _tableRebuildingService;
     private readonly IUserService _userService;
-    public UncertaintiesController(
-        IUncertaintyService uncertaintyService,
+    public utilitiesController(
+        IUtilityService utilityService,
         AppDbContext dbContext,
         ITableRebuildingService tableRebuildingService,
         IUserService userService)
         : base(dbContext)
     {
-        _uncertaintyService = uncertaintyService;
+        _utilityService = utilityService;
         _tableRebuildingService = tableRebuildingService;
         _userService = userService;
     }
 
-    [HttpGet("uncertainties/{id:guid}")]
-    public async Task<ActionResult<UncertaintyOutgoingDto>> GetUncertainty(Guid id, CancellationToken ct = default)
+    [HttpGet("utilities/{id:guid}")]
+    public async Task<ActionResult<UtilityOutgoingDto>> GetUtility(Guid id, CancellationToken ct = default)
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
-        var result = await _uncertaintyService.GetAsync(new List<Guid> { id }, user, ct);
+        var result = await _utilityService.GetAsync(new List<Guid> { id }, user, ct);
         return result.Count > 0 ? Ok(result[0]) : NotFound();
     }
 
-    [HttpGet("uncertainties")]
-    public async Task<ActionResult<List<UncertaintyOutgoingDto>>> GetAllUncertainties(CancellationToken ct = default)
+    [HttpGet("utilities")]
+    public async Task<ActionResult<List<UtilityOutgoingDto>>> GetAllutilities(CancellationToken ct = default)
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
-        var result = await _uncertaintyService.GetAllAsync(user, ct);
+        var result = await _utilityService.GetAllAsync(user, ct);
         return Ok(result);
     }
 
-    [HttpPut("uncertainties")]
-    public async Task<ActionResult<List<UncertaintyOutgoingDto>>> UpdateUncertainties([FromBody] List<UncertaintyIncomingDto> dtos, CancellationToken ct = default)
+    [HttpPut("utilities")]
+    public async Task<ActionResult<List<UtilityOutgoingDto>>> Updateutilities([FromBody] List<UtilityIncomingDto> dtos, CancellationToken ct = default)
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
 
         await BeginTransactionAsync(ct);
         try
         {
-            var result = await _uncertaintyService.UpdateAsync(dtos, user, ct);
+            var result = await _utilityService.UpdateAsync(dtos, user, ct);
             await _tableRebuildingService.RebuildTablesAsync(ct);
             await CommitTransactionAsync(ct);
             return Ok(result);
@@ -65,15 +65,15 @@ public class UncertaintiesController : PrismaBaseEntityController
         }
     }
 
-    [HttpDelete("uncertainties/{id:guid}")]
-    public async Task<IActionResult> DeleteUncertainty(Guid id, CancellationToken ct = default)
+    [HttpDelete("utilities/{id:guid}")]
+    public async Task<IActionResult> DeleteUtility(Guid id, CancellationToken ct = default)
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
 
         await BeginTransactionAsync(ct);
         try
         {
-            await _uncertaintyService.DeleteAsync(new List<Guid> { id }, user, ct);
+            await _utilityService.DeleteAsync(new List<Guid> { id }, user, ct);
             await CommitTransactionAsync(ct);
             return NoContent();
         }
@@ -84,15 +84,15 @@ public class UncertaintiesController : PrismaBaseEntityController
         }
     }
 
-    [HttpDelete("uncertainties")]
-    public async Task<IActionResult> DeleteUncertainties([FromQuery] List<Guid> ids, CancellationToken ct = default)
+    [HttpDelete("utilities")]
+    public async Task<IActionResult> Deleteutilities([FromQuery] List<Guid> ids, CancellationToken ct = default)
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
 
         await BeginTransactionAsync(ct);
         try
         {
-            await _uncertaintyService.DeleteAsync(ids, user, ct);
+            await _utilityService.DeleteAsync(ids, user, ct);
             await CommitTransactionAsync(ct);
             return NoContent();
         }
@@ -103,24 +103,17 @@ public class UncertaintiesController : PrismaBaseEntityController
         }
     }
 
-    [HttpPost("uncertainties/{id:guid}/remake-probability-table")]
-    public async Task<IActionResult> RemakeProbabilityTable(Guid id, CancellationToken ct = default)
-    {
-        await _tableRebuildingService.RebuildIssuesFromIssueIds([id], ct);
-        return Ok();
-    }
-
-    [HttpPost("uncertainties/{id:guid}/table_cleanup")]
-    public async Task<IActionResult> CleanupProbabilityTableAsync([FromQuery] Guid id, CancellationToken ct = default)
+    [HttpPost("utilities/{id:guid}/table_cleanup")]
+    public async Task<IActionResult> CleanupUtilityTableAsync([FromQuery] Guid id, CancellationToken ct = default) 
     {
         UserOutgoingDto user = HttpContext.GetLoadedUser();
         await BeginTransactionAsync(ct);
         try
         {
-            // check that the user has access to the uncertainty
-            var uncertainty = await _uncertaintyService.GetAsync([id], user, ct) ?? throw new ArgumentException($"Uncertainty {id} not found or User lacks access to the Project");
+            // check that the user has access to the utility
+            var utility = await _utilityService.GetAsync([id], user, ct) ?? throw new ArgumentException($"Utility {id} not found or User lacks access to the Project");
 
-            await _tableRebuildingService.RemoveExcessProbabilities(id, ct);
+            await _tableRebuildingService.RemoveExcessUtilities(id, ct);
             await CommitTransactionAsync(ct);
             return NoContent();
         }

--- a/PrismaApi/PrismaApi.Api/Controllers/UtilitesController.cs
+++ b/PrismaApi/PrismaApi.Api/Controllers/UtilitesController.cs
@@ -113,7 +113,7 @@ public class utilitiesController : PrismaBaseEntityController
             // check that the user has access to the utility
             var utility = await _utilityService.GetAsync([id], user, ct) ?? throw new ArgumentException($"Utility {id} not found or User lacks access to the Project");
 
-            await _tableRebuildingService.RemoveExcessUtilities(id, ct);
+            await _tableRebuildingService.RemoveExcessDiscreteUtilities(id, ct);
             await CommitTransactionAsync(ct);
             return NoContent();
         }

--- a/PrismaApi/PrismaApi.Application/Interfaces/Services/ITableRebuildingService.cs
+++ b/PrismaApi/PrismaApi.Application/Interfaces/Services/ITableRebuildingService.cs
@@ -4,4 +4,6 @@ public interface ITableRebuildingService
 {
     Task RebuildTablesAsync(CancellationToken ct = default);
     Task RebuildIssuesFromIssueIds(ICollection<Guid> issueIds, CancellationToken ct = default);
+    Task RemoveExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default);
+    Task RemoveExcessUtilities(Guid utilityId, CancellationToken ct = default);
 }

--- a/PrismaApi/PrismaApi.Application/Interfaces/Services/ITableRebuildingService.cs
+++ b/PrismaApi/PrismaApi.Application/Interfaces/Services/ITableRebuildingService.cs
@@ -4,6 +4,6 @@ public interface ITableRebuildingService
 {
     Task RebuildTablesAsync(CancellationToken ct = default);
     Task RebuildIssuesFromIssueIds(ICollection<Guid> issueIds, CancellationToken ct = default);
-    Task RemoveExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default);
-    Task RemoveExcessUtilities(Guid utilityId, CancellationToken ct = default);
+    Task RemoveExcessDiscreteProbabilities(Guid uncertaintyId, CancellationToken ct = default);
+    Task RemoveExcessDiscreteUtilities(Guid utilityId, CancellationToken ct = default);
 }

--- a/PrismaApi/PrismaApi.Application/Services/TableRebuildingService.cs
+++ b/PrismaApi/PrismaApi.Application/Services/TableRebuildingService.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using PrismaApi.Application.Interfaces.Services;
 using PrismaApi.Domain.Constants;
+using PrismaApi.Domain.Dtos;
 using PrismaApi.Domain.Entities;
 using PrismaApi.Infrastructure.Context;
 
 namespace PrismaApi.Application.Services;
 
-public class TableRebuildingService: ITableRebuildingService
+public class TableRebuildingService : ITableRebuildingService
 {
     protected readonly AppDbContext DbContext;
     public TableRebuildingService(AppDbContext dbContext)
@@ -243,6 +244,65 @@ public class TableRebuildingService: ITableRebuildingService
         }
 
         return (parentOutcomesList, parentOptionsList);
+    }
+
+    public async Task RemoveExcessDataInTables(Guid projectId, UserOutgoingDto user, CancellationToken ct = default)
+    {
+        var uncertaintyIds = await DbContext.Uncertainties
+            .Where(x => x.Issue!.ProjectId == projectId && x.Issue!.Project!.ProjectRoles.Any(p => p.UserId == user.Id))
+            .Select(e => e.Id).ToListAsync(ct);
+        var utilityIds = await DbContext.Utilities
+            .Where(x => x.Issue!.ProjectId == projectId && x.Issue!.Project!.ProjectRoles.Any(p => p.UserId == user.Id))
+            .Select(e => e.Id).ToListAsync(ct);
+        foreach (var id in uncertaintyIds) await RemoveExcessProbabilities(id, ct);
+        foreach (var id in utilityIds) await RemoveExcessUtilities(id, ct);
+        await DbContext.SaveChangesAsync(ct);
+    }
+
+    public async Task RemoveExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default)
+    {
+        var probs = await FindExcessProbabilities(uncertaintyId, ct);
+        RemoveDiscreteProbabilities(probs);
+    }
+
+    public async Task RemoveExcessUtilities(Guid utilityId, CancellationToken ct = default)
+    {
+        var utls = await FindExcessUtility(utilityId, ct);
+        RemoveDiscreteUtilities(utls);
+    }
+
+    private async Task<IEnumerable<DiscreteProbability>> FindExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default)
+    {
+        var probabilities = await DbContext.DiscreteProbabilities
+            .Where(p => p.UncertaintyId == uncertaintyId)
+            .Include(p => p.ParentOutcomes)
+            .Include(p => p.ParentOptions)
+            .ToListAsync(ct);
+
+        return probabilities
+            .GroupBy(p => (
+                p.OutcomeId,
+                ParentOutcomes: string.Join(",", p.ParentOutcomes.Select(o => o.ParentOutcomeId).OrderBy(id => id)),
+                ParentOptions: string.Join(",", p.ParentOptions.Select(o => o.ParentOptionId).OrderBy(id => id))
+            ))
+            .SelectMany(group => group.Skip(1));
+    }
+
+    private async Task<IEnumerable<DiscreteUtility>> FindExcessUtility(Guid utilityId, CancellationToken ct = default)
+    {
+        var utilities = await DbContext.DiscreteUtilities
+            .Where(p => p.UtilityId == utilityId)
+            .Include(p => p.ParentOutcomes)
+            .Include(p => p.ParentOptions)
+            .ToListAsync(ct);
+
+        return utilities
+            .GroupBy(p => (
+                p.ValueMetricId,
+                ParentOutcomes: string.Join(",", p.ParentOutcomes.Select(o => o.ParentOutcomeId).OrderBy(id => id)),
+                ParentOptions: string.Join(",", p.ParentOptions.Select(o => o.ParentOptionId).OrderBy(id => id))
+            ))
+            .SelectMany(group => group.Skip(1));
     }
 
     private void RemoveDiscreteProbabilities(IEnumerable<DiscreteProbability> probabilities)

--- a/PrismaApi/PrismaApi.Application/Services/TableRebuildingService.cs
+++ b/PrismaApi/PrismaApi.Application/Services/TableRebuildingService.cs
@@ -248,38 +248,38 @@ public class TableRebuildingService : ITableRebuildingService
 
     public async Task RemoveExcessDataInTables(Guid projectId, UserOutgoingDto user, CancellationToken ct = default)
     {
-        var uncertaintyIds = await DbContext.Uncertainties
+        var discreteUncertaintyIds = await DbContext.Uncertainties
             .Where(x => x.Issue!.ProjectId == projectId && x.Issue!.Project!.ProjectRoles.Any(p => p.UserId == user.Id))
             .Select(e => e.Id).ToListAsync(ct);
-        var utilityIds = await DbContext.Utilities
+        var discreteUtilityIds = await DbContext.Utilities
             .Where(x => x.Issue!.ProjectId == projectId && x.Issue!.Project!.ProjectRoles.Any(p => p.UserId == user.Id))
             .Select(e => e.Id).ToListAsync(ct);
-        foreach (var id in uncertaintyIds) await RemoveExcessProbabilities(id, ct);
-        foreach (var id in utilityIds) await RemoveExcessUtilities(id, ct);
+        foreach (var id in discreteUncertaintyIds) await RemoveExcessDiscreteProbabilities(id, ct);
+        foreach (var id in discreteUtilityIds) await RemoveExcessDiscreteUtilities(id, ct);
         await DbContext.SaveChangesAsync(ct);
     }
 
-    public async Task RemoveExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default)
+    public async Task RemoveExcessDiscreteProbabilities(Guid uncertaintyId, CancellationToken ct = default)
     {
-        var probs = await FindExcessProbabilities(uncertaintyId, ct);
-        RemoveDiscreteProbabilities(probs);
+        var discreteProbabilities = await FindExcessDiscreteProbabilities(uncertaintyId, ct);
+        RemoveDiscreteProbabilities(discreteProbabilities);
     }
 
-    public async Task RemoveExcessUtilities(Guid utilityId, CancellationToken ct = default)
+    public async Task RemoveExcessDiscreteUtilities(Guid utilityId, CancellationToken ct = default)
     {
-        var utls = await FindExcessUtility(utilityId, ct);
-        RemoveDiscreteUtilities(utls);
+        var discreteUtilities = await FindExcessDiscreteUtility(utilityId, ct);
+        RemoveDiscreteUtilities(discreteUtilities);
     }
 
-    private async Task<IEnumerable<DiscreteProbability>> FindExcessProbabilities(Guid uncertaintyId, CancellationToken ct = default)
+    private async Task<IEnumerable<DiscreteProbability>> FindExcessDiscreteProbabilities(Guid uncertaintyId, CancellationToken ct = default)
     {
-        var probabilities = await DbContext.DiscreteProbabilities
+        var discreteProbabilities = await DbContext.DiscreteProbabilities
             .Where(p => p.UncertaintyId == uncertaintyId)
             .Include(p => p.ParentOutcomes)
             .Include(p => p.ParentOptions)
             .ToListAsync(ct);
 
-        return probabilities
+        return discreteProbabilities
             .GroupBy(p => (
                 p.OutcomeId,
                 ParentOutcomes: string.Join(",", p.ParentOutcomes.Select(o => o.ParentOutcomeId).OrderBy(id => id)),
@@ -288,15 +288,15 @@ public class TableRebuildingService : ITableRebuildingService
             .SelectMany(group => group.Skip(1));
     }
 
-    private async Task<IEnumerable<DiscreteUtility>> FindExcessUtility(Guid utilityId, CancellationToken ct = default)
+    private async Task<IEnumerable<DiscreteUtility>> FindExcessDiscreteUtility(Guid utilityId, CancellationToken ct = default)
     {
-        var utilities = await DbContext.DiscreteUtilities
+        var discreteUtilities = await DbContext.DiscreteUtilities
             .Where(p => p.UtilityId == utilityId)
             .Include(p => p.ParentOutcomes)
             .Include(p => p.ParentOptions)
             .ToListAsync(ct);
 
-        return utilities
+        return discreteUtilities
             .GroupBy(p => (
                 p.ValueMetricId,
                 ParentOutcomes: string.Join(",", p.ParentOutcomes.Select(o => o.ParentOutcomeId).OrderBy(id => id)),
@@ -305,34 +305,34 @@ public class TableRebuildingService : ITableRebuildingService
             .SelectMany(group => group.Skip(1));
     }
 
-    private void RemoveDiscreteProbabilities(IEnumerable<DiscreteProbability> probabilities)
+    private void RemoveDiscreteProbabilities(IEnumerable<DiscreteProbability> discreteProbabilities)
     {
-        var probabilityIds = probabilities.Select(probability => probability.Id).ToList();
-        if (probabilityIds.Count == 0)
+        var discreteProbabilityIds = discreteProbabilities.Select(probability => probability.Id).ToList();
+        if (discreteProbabilityIds.Count == 0)
         {
             return;
         }
 
         DbContext.DiscreteProbabilityParentOutcomes.RemoveRange(
-            DbContext.DiscreteProbabilityParentOutcomes.Where(parent => probabilityIds.Contains(parent.DiscreteProbabilityId)));
+            DbContext.DiscreteProbabilityParentOutcomes.Where(parent => discreteProbabilityIds.Contains(parent.DiscreteProbabilityId)));
         DbContext.DiscreteProbabilityParentOptions.RemoveRange(
-            DbContext.DiscreteProbabilityParentOptions.Where(parent => probabilityIds.Contains(parent.DiscreteProbabilityId)));
-        DbContext.DiscreteProbabilities.RemoveRange(probabilities);
+            DbContext.DiscreteProbabilityParentOptions.Where(parent => discreteProbabilityIds.Contains(parent.DiscreteProbabilityId)));
+        DbContext.DiscreteProbabilities.RemoveRange(discreteProbabilities);
     }
 
-    private void RemoveDiscreteUtilities(IEnumerable<DiscreteUtility> utilities)
+    private void RemoveDiscreteUtilities(IEnumerable<DiscreteUtility> discreteUtilities)
     {
-        var utilityIds = utilities.Select(utility => utility.Id).ToList();
-        if (utilityIds.Count == 0)
+        var discreteUtilityIds = discreteUtilities.Select(utility => utility.Id).ToList();
+        if (discreteUtilityIds.Count == 0)
         {
             return;
         }
 
         DbContext.DiscreteUtilityParentOutcomes.RemoveRange(
-            DbContext.DiscreteUtilityParentOutcomes.Where(parent => utilityIds.Contains(parent.DiscreteUtilityId)));
+            DbContext.DiscreteUtilityParentOutcomes.Where(parent => discreteUtilityIds.Contains(parent.DiscreteUtilityId)));
         DbContext.DiscreteUtilityParentOptions.RemoveRange(
-            DbContext.DiscreteUtilityParentOptions.Where(parent => utilityIds.Contains(parent.DiscreteUtilityId)));
-        DbContext.DiscreteUtilities.RemoveRange(utilities);
+            DbContext.DiscreteUtilityParentOptions.Where(parent => discreteUtilityIds.Contains(parent.DiscreteUtilityId)));
+        DbContext.DiscreteUtilities.RemoveRange(discreteUtilities);
     }
 
     private static List<List<Guid>> BuildCombinations(List<List<Guid>> groups)


### PR DESCRIPTION
Introduced a new utilitiesController with full CRUD endpoints and a table cleanup endpoint to remove duplicate utility rows. Added a POST endpoint to UncertaintiesController for cleaning up excess probability rows. Extended ITableRebuildingService and TableRebuildingService to support removal of duplicate probabilities and utilities, ensuring only unique rows per combination of outcome/value metric, parent outcomes, and parent options. All new endpoints include user context checks and transaction management.