### PR TITLE
Add workflow to auto-label issues with pr_Prisma

### DIFF
--- a/.github/workflows/auto-label-pr-prisma.yml
+++ b/.github/workflows/auto-label-pr-prisma.yml
@@ -1,0 +1,21 @@
+name: Auto-label pr_Prisma
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['pr_Prisma']
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically applies the `pr_Prisma` label to every new issue created in this repository.

## Why

The Team GitHub Project board uses label-based views to filter tasks per project. Previously, contributors had to manually add the label to each new issue. This workflow eliminates that manual step.

## What it does

- Triggers on `issues: opened`
- Adds the `pr_Prisma` label automatically

## Next steps

The same workflow file should be added to:
- `prisma-decision-web`
- `prisma-decision-docs`
- `prisma-decision-infrustructure`