### PR TITLE
fix: always add the current user as facilitor when dupicating or importing a project

### DIFF
--- a/PrismaDotnetApi/PrismaApi.Application/Services/ProjectduplicationService.cs
+++ b/PrismaDotnetApi/PrismaApi.Application/Services/ProjectduplicationService.cs
@@ -72,6 +72,7 @@ public class ProjectDuplicationService : IProjectDuplicationService
             mappings);
 
         var createProjectDto = CreateProjectDto(fullProject, newProjectId);
+        EnsureUserIsFacilitator(createProjectDto, user);
         var createdProjects = await _projectService.CreateAsync([createProjectDto], createDefaultRole, userDto: user);
         var createdProject = createdProjects[0];
 
@@ -177,6 +178,7 @@ public class ProjectDuplicationService : IProjectDuplicationService
         mappings.Project[importedProjectId] = newProjectId;
 
         var createProjectDto = CreateProjectDtoFromImport(dto.Projects, newProjectId);
+        EnsureUserIsFacilitator(createProjectDto, user);
         var createdProjects = await _projectService.CreateAsync([createProjectDto], createDefaultRole: false, userDto: user);
         if (createdProjects.Count == 0)
             return null;
@@ -317,6 +319,25 @@ public class ProjectDuplicationService : IProjectDuplicationService
                 })
                 .ToList()
         };
+    }
+
+    private static void EnsureUserIsFacilitator(ProjectCreateDto project, UserOutgoingDto user)
+    {
+        var userRole = project.Users.FirstOrDefault(role => role.UserId == user.Id);
+        if (userRole is not null)
+        {
+            userRole.Role = ProjectRoleType.Facilitator.ToString();
+            return;
+        }
+
+        project.Users.Add(new ProjectRoleCreateDto
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = project.Id,
+            UserId = user.Id,
+            Name = user.Name,
+            Role = ProjectRoleType.Facilitator.ToString()
+        });
     }
 
     private static DecisionIncomingDto? CreateDecision(

--- a/PrismaDotnetApi/PrismaApi.Test/ControllerTests/ProjectsControllerTests.cs
+++ b/PrismaDotnetApi/PrismaApi.Test/ControllerTests/ProjectsControllerTests.cs
@@ -192,6 +192,57 @@ public class ProjectsControllerTests : PrismaApiControllerTestBase
     }
 
     [Fact]
+    public async Task DuplicateProject_AsNonFacilitator_MakesUserFacilitator()
+    {
+        using var scope = _fixture.SecondaryUserScope();
+
+        var duplicateResponse = await Client.TestClientPostNoPayloadAsync<ProjectOutgoingDto>(
+            $"projects/{_fixture.TestArgs.SecondaryProjectId}/duplicate");
+
+        Assert.Equal(HttpStatusCode.OK, duplicateResponse.Response.StatusCode);
+        var userRole = Assert.Single(duplicateResponse.Value.Users,
+            role => role.UserId == _fixture.SecondaryUser.Id);
+        Assert.Equal(ProjectRoleType.Facilitator.ToString(), userRole.Role);
+    }
+
+    [Fact]
+    public async Task ImportProject_WithoutUserRole_AddsUserAsFacilitator()
+    {
+        using var scope = _fixture.SecondaryUserScope();
+        var sourceProjectId = Guid.NewGuid();
+
+        var importResponse = await Client.TestClientPostAsync<List<ProjectOutgoingDto>>("projects/import",
+            new List<ProjectImportDto>
+            {
+                new()
+                {
+                    Projects = new ProjectIncomingDto
+                    {
+                        Id = sourceProjectId,
+                        Name = "Imported Project Without Current User",
+                        Users =
+                        [
+                            new ProjectRoleIncomingDto
+                            {
+                                Id = Guid.NewGuid(),
+                                ProjectId = sourceProjectId,
+                                UserId = _fixture.PrismaUser.Id!,
+                                Name = _fixture.PrismaUser.Name!,
+                                Role = ProjectRoleType.Facilitator.ToString()
+                            }
+                        ]
+                    }
+                }
+            });
+
+        Assert.Equal(HttpStatusCode.OK, importResponse.Response.StatusCode);
+        var importedProject = Assert.Single(importResponse.Value);
+        var userRole = Assert.Single(importedProject.Users,
+            role => role.UserId == _fixture.SecondaryUser.Id);
+        Assert.Equal(ProjectRoleType.Facilitator.ToString(), userRole.Role);
+    }
+
+    [Fact]
     public async Task ImportProject_ResetsFavoriteForAllUsers()
     {
         var sourceProjectId = Guid.NewGuid();


### PR DESCRIPTION
fix: always add the current user as facilitor when dupicating or importing a project